### PR TITLE
Add -s and -z tests.

### DIFF
--- a/src/tests/junit-upload.spec.ts
+++ b/src/tests/junit-upload.spec.ts
@@ -56,7 +56,17 @@ const countResultUploadApiCalls = () =>
 
 describe('Uploading JUnit xml files', () => {
 	describe('Argument parsing', () => {
-		test('Passed --url argument should use https when protocol is omitted', async () => {
+		test('Passing -s and -z argument should use the correct URL', async () => {
+			const fileUploadCount = countFileUploadApiCalls()
+			const tcaseUploadCount = countResultUploadApiCalls()
+			await run(
+				`junit-upload -s ${domain} -z ${zone} -p ${projectCode} -r ${runId} -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
+			)
+			expect(fileUploadCount()).toBe(0)
+			expect(tcaseUploadCount()).toBe(5)
+		})
+
+		test('Passing --url argument should use https when protocol is omitted', async () => {
 			const fileUploadCount = countFileUploadApiCalls()
 			const tcaseUploadCount = countResultUploadApiCalls()
 			await run(


### PR DESCRIPTION
Added these tests since these arguments can't be tested on localhost, staging, or dev.

So I'm adding these tests just for the confidence it will work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated a test case to verify the correct URL construction when using `-s` and `-z` arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->