### PR TITLE
Enhance qas-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,5 @@ qasphere junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 -
 1. Build the code with `npm run build`.
 2. Create a project with test cases using local QASphere build or by registering on [qasphere.com](https://qasphere.com/)
 3. Get a JUnit XML file. If you want to test the test cases from the CSV file above, use the JUnit XML file generated from [this repository](https://github.com/Hypersequent/bistrot-e2e).
-
-4. Run the CLI with: `node ./build/bin/qasphere.js junit-upload ./JUnit.xml --run-url https://YOUR_DOMAIN.eu1.qasphere.com -p PROJECT_CODE -r RUN_ID -t API_TOKEN`
+4. Run the CLI with: `node ./build/bin/qasphere.js junit-upload -r QAS_URL/project/PROJECT_CODE/run/RUN_ID -t API_TOKEN ./JUnit.xml`. If you get permission errors, please retry after running: `chmod +x ./build/bin/qasphere.js`
 5. You may pass the `-h` flag to show help: `node ./build/bin/qasphere junit-upload -h`

--- a/README.md
+++ b/README.md
@@ -38,20 +38,20 @@ qasphere --version
 ### Options
 
 - `-t, --token` - API token (string) - Can be generated under QASphere **Settings>API keys**
-- `-r, --run-url` - URL of the Run (from QASphere) for uploading results, eg. https://qas.eu1.qasphere.com/project/TEST/run/1/tcase/1 (string)
+- `-r, --run-url` - URL of the Run (from QASphere) for uploading results, eg. https://qas.eu1.qasphere.com/project/P1/run/23 (string)
 - `--attachments` - Try to detect any attachments and upload it with the test result (boolean)
 - `--force` - Ignore API request errors, invalid test cases, or attachments (boolean)
 - `-h, --help` - Show help (boolean)
 
 ### Examples
 
-1. Upload JUnit XML file to `https://qas.eu1.qasphere.com/project/P1/run/23`
+1. Upload JUnit XML file to Run ID 23 of Project P1
 
 ```bash
 qasphere junit-upload -r https://qas.eu1.qasphere.com/project/P1/run/23 -t API_TOKEN ./path/to/junit.xml
 ```
 
-2. To upload all (JUnit) XML files from the current directory to `https://qas.eu1.qasphere.com/project/P1/run/23`
+2. To upload all (JUnit) XML files from the current directory to Run ID 23 of Project P1
 
 ```bash
 qasphere junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 --token API_TOKEN ./*.xml

--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ qasphere junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 -
 2. Create a project with test cases using local QASphere build or by registering on [qasphere.com](https://qasphere.com/)
 3. Get a JUnit XML file. If you want to test the test cases from the CSV file above, use the JUnit XML file generated from [this repository](https://github.com/Hypersequent/bistrot-e2e).
 
-4. Run the CLI with: `node ./build/bin/qasphere.js junit-upload ./JUnit.xml --url https://YOUR_DOMAIN.eu1.qasphere.com -p PROJECT_CODE -r RUN_ID -t API_TOKEN`
+4. Run the CLI with: `node ./build/bin/qasphere.js junit-upload ./JUnit.xml --run-url https://YOUR_DOMAIN.eu1.qasphere.com -p PROJECT_CODE -r RUN_ID -t API_TOKEN`
 5. You may pass the `-h` flag to show help: `node ./build/bin/qasphere junit-upload -h`

--- a/README.md
+++ b/README.md
@@ -37,12 +37,8 @@ qasphere --version
 
 ### Options
 
-- `-s, --subdomain` - URL subdomain (string) (**YOUR_DOMAIN**.eu1.qasphere.com)
-- `-z, --zone` - URL zone (string) (YOUR_DOMAIN.**eu1**.qasphere.com)
-- `-p, --project` - Project code (string) (required) from project URL (YOUR_DOMAIN.eu1.qasphere.com/project/**TES**/overview)
-- `-r, --run` - Run ID (number) (required) from test run URL (YOUR_DOMAIN.eu1.qasphere.com/project/TES/run/**11**)
-- `-t, --token` - API token (string) - can be generated under QASphere **Settings>API keys**
-- `--url` - Instance URL (string) - like **YOUR_DOMAIN.eu1.qasphere.com**
+- `-t, --token` - API token (string) - Can be generated under QASphere **Settings>API keys**
+- `-r, --run-url` - URL of the Run (from QASphere) for uploading results, eg. https://qas.eu1.qasphere.com/project/TEST/run/1/tcase/1 (string)
 - `--attachments` - Try to detect any attachments and upload it with the test result (boolean)
 - `--force` - Ignore API request errors, invalid test cases, or attachments (boolean)
 - `-h, --help` - Show help (boolean)
@@ -52,13 +48,13 @@ qasphere --version
 1. Upload JUnit XML file to `https://qas.eu1.qasphere.com/project/P1/run/23`
 
 ```bash
-qasphere junit-upload -s qas -z eu1 -p P1 -r 23 -t API_TOKEN ./path/to/junit.xml
+qasphere junit-upload -r https://qas.eu1.qasphere.com/project/P1/run/23 -t API_TOKEN ./path/to/junit.xml
 ```
 
-2. To upload JUnit XML file to `https://qas.eu1.qasphere.com/project/P1/run/23`
+2. To upload all (JUnit) XML files from the current directory to `https://qas.eu1.qasphere.com/project/P1/run/23`
 
 ```bash
-qasphere junit-upload --url https://qas.eu1.hpsq.io -p P1 -r 23 -t API_TOKEN  ./path/to/junit.xml
+qasphere junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 --token API_TOKEN ./*.xml
 ```
 
 ## How to Test
@@ -66,5 +62,6 @@ qasphere junit-upload --url https://qas.eu1.hpsq.io -p P1 -r 23 -t API_TOKEN  ./
 1. Build the code with `npm run build`.
 2. Create a project with test cases using local QASphere build or by registering on [qasphere.com](https://qasphere.com/)
 3. Get a JUnit XML file. If you want to test the test cases from the CSV file above, use the JUnit XML file generated from [this repository](https://github.com/Hypersequent/bistrot-e2e).
+
 4. Run the CLI with: `node ./build/bin/qasphere.js junit-upload ./JUnit.xml --url https://YOUR_DOMAIN.eu1.qasphere.com -p PROJECT_CODE -r RUN_ID -t API_TOKEN`
 5. You may pass the `-h` flag to show help: `node ./build/bin/qasphere junit-upload -h`

--- a/src/commands/junit-upload.ts
+++ b/src/commands/junit-upload.ts
@@ -1,59 +1,31 @@
 import { Arguments, Argv, CommandModule } from 'yargs'
-import { parseUrl } from '../utils/misc'
+import { parseRunUrl } from '../utils/misc'
 import { API_TOKEN } from '../config/env'
 import { JUnitCommandHandler } from '../utils/junit/JUnitCommandHandler'
 
 export interface JUnitArgs {
-	subdomain: string
-	zone: string
-	project: string
-	run: number
+	runUrl: string
 	token: string
-	file: string
+	files: string[]
 	force: boolean
 	attachments: boolean
 }
 
 export class JUnitUploadCommandModule implements CommandModule<unknown, JUnitArgs> {
-	command = 'junit-upload [args..] <file>'
+	command = 'junit-upload [args..] <files..>'
 	describe = 'upload JUnit xml files'
 
 	builder = (argv: Argv) => {
 		argv.options({
-			subdomain: {
-				alias: 's',
-				type: 'string',
-				describe: 'URL subdomain',
-				requiresArg: true,
-			},
-			zone: {
-				alias: 'z',
-				type: 'string',
-				describe: 'URL zone',
-				requiresArg: true,
-			},
-			project: {
-				alias: 'p',
-				type: 'string',
-				describe: 'Project code',
-				demandOption: true,
-				requiresArg: true,
-			},
-			run: {
-				alias: 'r',
-				type: 'number',
-				describe: 'Run ID',
-				demandOption: true,
-				requiresArg: true,
-			},
 			token: {
 				alias: 't',
 				describe: 'API token',
 				type: 'string',
 				requiresArg: true,
 			},
-			url: {
-				describe: 'Instance URL',
+			'run-url': {
+				alias: 'r',
+				describe: 'URL of the Run (from QASphere) for uploading results',
 				type: 'string',
 				requiresArg: true,
 			},
@@ -72,7 +44,7 @@ export class JUnitUploadCommandModule implements CommandModule<unknown, JUnitArg
 		})
 
 		argv.check((args) => {
-			return !!parseUrl(args)
+			return !!parseRunUrl(args)
 		})
 
 		argv.check((args) => {
@@ -83,13 +55,13 @@ export class JUnitUploadCommandModule implements CommandModule<unknown, JUnitArg
 		})
 
 		argv.example(
-			'$0 junit-upload -s qas -z eu1 -p P1 -r 23 -t API_TOKEN ./path/to/junit.xml ',
+			'$0 junit-upload -r https://qas.eu1.qasphere.com/project/P1/run/23 -t API_TOKEN ./path/to/junit.xml',
 			'Upload JUnit xml file to https://qas.eu1.qasphere.com/project/P1/run/23'
 		)
 
 		argv.example(
-			'$0 junit-upload --url qas.eu1.hpsq.io -p P1 -r 23 -t API_TOKEN  ./path/to/junit.xml',
-			'Upload JUnit xml file to https://qas.eu1.qasphere.com/project/P1/run/23'
+			'$0 junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 --token API_TOKEN *.xml',
+			'Upload all xml files in the current directory to https://qas.eu1.qasphere.com/project/P1/run/23'
 		)
 
 		return argv as Argv<JUnitArgs>

--- a/src/commands/junit-upload.ts
+++ b/src/commands/junit-upload.ts
@@ -56,12 +56,12 @@ export class JUnitUploadCommandModule implements CommandModule<unknown, JUnitArg
 
 		argv.example(
 			'$0 junit-upload -r https://qas.eu1.qasphere.com/project/P1/run/23 -t API_TOKEN ./path/to/junit.xml',
-			'Upload JUnit xml file to https://qas.eu1.qasphere.com/project/P1/run/23'
+			'Upload JUnit xml file to Run ID 23 of Project P1'
 		)
 
 		argv.example(
 			'$0 junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 --token API_TOKEN *.xml',
-			'Upload all xml files in the current directory to https://qas.eu1.qasphere.com/project/P1/run/23'
+			'Upload all xml files in the current directory to Run ID 23 of Project P1'
 		)
 
 		return argv as Argv<JUnitArgs>

--- a/src/tests/junit-upload.spec.ts
+++ b/src/tests/junit-upload.spec.ts
@@ -57,23 +57,19 @@ const countResultUploadApiCalls = () =>
 describe('Uploading JUnit xml files', () => {
 	describe('Argument parsing', () => {
 		test('Passing correct Run URL pattern should result in success', async () => {
-			const fileUploadCount = countFileUploadApiCalls()
-			const tcaseUploadCount = countResultUploadApiCalls()
-			await run(
-				`junit-upload --run-url ${runURL} --token API_TOKEN ${xmlBasePath}/matching-tcases.xml`
-			)
-			expect(fileUploadCount()).toBe(0)
-			expect(tcaseUploadCount()).toBe(5)
-		})
+			const patterns = [
+				`junit-upload --run-url ${runURL} --token API_TOKEN ${xmlBasePath}/matching-tcases.xml`,
+				`junit-upload -r ${runURL}/ -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`,
+				`junit-upload -r ${runURL}/tcase/1 -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`,
+			]
 
-		test('Passing correct Run URL pattern with extra / at the end, should result in success', async () => {
-			const fileUploadCount = countFileUploadApiCalls()
-			const tcaseUploadCount = countResultUploadApiCalls()
-			await run(
-				`junit-upload -r ${runURL}/ -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
-			)
-			expect(fileUploadCount()).toBe(0)
-			expect(tcaseUploadCount()).toBe(5)
+			for (const pattern of patterns) {
+				const fileUploadCount = countFileUploadApiCalls()
+				const tcaseUploadCount = countResultUploadApiCalls()
+				await run(pattern)
+				expect(fileUploadCount()).toBe(0)
+				expect(tcaseUploadCount()).toBe(5)
+			}
 		})
 
 		test('Passing correct Run URL pattern without https, should result in success', async () => {
@@ -87,20 +83,25 @@ describe('Uploading JUnit xml files', () => {
 		})
 
 		test('Passing incorrect Run URL pattern should result in failure', async () => {
-			const fileUploadCount = countFileUploadApiCalls()
-			const tcaseUploadCount = countResultUploadApiCalls()
-			let isError = false
+			const patterns = [
+				`junit-upload -r ${qasHost}/projects/${projectCode}/runs/${runId} -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`,
+				`junit-upload -r ${runURL}abc/tcase/1 -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`,
+			]
 
-			try {
-				await run(
-					`junit-upload -r ${qasHost}/projects/${projectCode}/runs/${runId} -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
-				)
-			} catch(error) {
-				isError = true
+			for (const pattern of patterns) {
+				const fileUploadCount = countFileUploadApiCalls()
+				const tcaseUploadCount = countResultUploadApiCalls()
+				let isError = false
+
+				try {
+					await run(pattern)
+				} catch (error) {
+					isError = true
+				}
+				expect(isError).toBeTruthy()
+				expect(fileUploadCount()).toBe(0)
+				expect(tcaseUploadCount()).toBe(0)
 			}
-			expect(isError).toBeTruthy()
-			expect(fileUploadCount()).toBe(0)
-			expect(tcaseUploadCount()).toBe(0)
 		})
 	})
 

--- a/src/tests/junit-upload.spec.ts
+++ b/src/tests/junit-upload.spec.ts
@@ -7,9 +7,9 @@ import { countMockedApiCalls } from './utils'
 
 const projectCode = 'TEST'
 const runId = '1'
-const domain = 'qas'
-const zone = 'eu1'
-const baseURL = `https://${domain}.${zone}.qasphere.com`
+const qasHost = 'qas.eu1.qasphere.com'
+const baseURL = `https://${qasHost}`
+const runURL = `${baseURL}/project/${projectCode}/run/${runId}`
 const xmlBasePath = './src/tests/fixtures/junit-xml'
 
 const server = setupServer(
@@ -56,24 +56,51 @@ const countResultUploadApiCalls = () =>
 
 describe('Uploading JUnit xml files', () => {
 	describe('Argument parsing', () => {
-		test('Passing -s and -z argument should use the correct URL', async () => {
+		test('Passing correct Run URL pattern should result in success', async () => {
 			const fileUploadCount = countFileUploadApiCalls()
 			const tcaseUploadCount = countResultUploadApiCalls()
 			await run(
-				`junit-upload -s ${domain} -z ${zone} -p ${projectCode} -r ${runId} -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
+				`junit-upload --run-url ${runURL} --token API_TOKEN ${xmlBasePath}/matching-tcases.xml`
 			)
 			expect(fileUploadCount()).toBe(0)
 			expect(tcaseUploadCount()).toBe(5)
 		})
 
-		test('Passing --url argument should use https when protocol is omitted', async () => {
+		test('Passing correct Run URL pattern with extra / at the end, should result in success', async () => {
 			const fileUploadCount = countFileUploadApiCalls()
 			const tcaseUploadCount = countResultUploadApiCalls()
 			await run(
-				`junit-upload --url ${domain}.${zone}.qasphere.com -p ${projectCode} -r ${runId} -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
+				`junit-upload -r ${runURL}/ -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
 			)
 			expect(fileUploadCount()).toBe(0)
 			expect(tcaseUploadCount()).toBe(5)
+		})
+
+		test('Passing correct Run URL pattern without https, should result in success', async () => {
+			const fileUploadCount = countFileUploadApiCalls()
+			const tcaseUploadCount = countResultUploadApiCalls()
+			await run(
+				`junit-upload -r ${qasHost}/project/${projectCode}/run/${runId} -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
+			)
+			expect(fileUploadCount()).toBe(0)
+			expect(tcaseUploadCount()).toBe(5)
+		})
+
+		test('Passing incorrect Run URL pattern should result in failure', async () => {
+			const fileUploadCount = countFileUploadApiCalls()
+			const tcaseUploadCount = countResultUploadApiCalls()
+			let isError = false
+
+			try {
+				await run(
+					`junit-upload -r ${qasHost}/projects/${projectCode}/runs/${runId} -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
+				)
+			} catch(error) {
+				isError = true
+			}
+			expect(isError).toBeTruthy()
+			expect(fileUploadCount()).toBe(0)
+			expect(tcaseUploadCount()).toBe(0)
 		})
 	})
 
@@ -82,7 +109,7 @@ describe('Uploading JUnit xml files', () => {
 			const fileUploadCount = countFileUploadApiCalls()
 			const tcaseUploadCount = countResultUploadApiCalls()
 			await run(
-				`junit-upload --url ${baseURL} -p ${projectCode} -r ${runId} -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
+				`junit-upload -r ${runURL} -t API_TOKEN ${xmlBasePath}/matching-tcases.xml`
 			)
 			expect(fileUploadCount()).toBe(0)
 			expect(tcaseUploadCount()).toBe(5)
@@ -93,9 +120,9 @@ describe('Uploading JUnit xml files', () => {
 			const tcaseUploadCount = countResultUploadApiCalls()
 			await expect(
 				run(
-					`junit-upload --url ${baseURL} -p ${projectCode} -r ${runId} -t API_TOKEN ${xmlBasePath}/missing-tcases.xml`
+					`junit-upload -r ${runURL} -t API_TOKEN ${xmlBasePath}/missing-tcases.xml`
 				)
-			).rejects.toThrow()
+			).rejects.toThrowError()
 			expect(fileUploadCount()).toBe(0)
 			expect(tcaseUploadCount()).toBe(0)
 		})
@@ -104,10 +131,20 @@ describe('Uploading JUnit xml files', () => {
 			const fileUploadCount = countFileUploadApiCalls()
 			const tcaseUploadCount = countResultUploadApiCalls()
 			await run(
-				`junit-upload --url ${baseURL} -p ${projectCode} -r ${runId} -t API_TOKEN --force ${xmlBasePath}/missing-tcases.xml`
+				`junit-upload -r ${runURL} -t API_TOKEN --force ${xmlBasePath}/missing-tcases.xml`
 			)
 			expect(fileUploadCount()).toBe(0)
 			expect(tcaseUploadCount()).toBe(4)
+		})
+
+		test('Test cases from muliple xml files should be processed successfully', async () => {
+			const fileUploadCount = countFileUploadApiCalls()
+			const tcaseUploadCount = countResultUploadApiCalls()
+			await run(
+				`junit-upload -r ${runURL} -t API_TOKEN --force ${xmlBasePath}/missing-tcases.xml ${xmlBasePath}/missing-tcases.xml`
+			)
+			expect(fileUploadCount()).toBe(0)
+			expect(tcaseUploadCount()).toBe(8)
 		})
 	})
 
@@ -116,7 +153,7 @@ describe('Uploading JUnit xml files', () => {
 			const fileUploadCount = countFileUploadApiCalls()
 			const tcaseUploadCount = countResultUploadApiCalls()
 			await run(
-				`junit-upload --url ${baseURL} -p ${projectCode} -r ${runId} -t API_TOKEN --attachments ${xmlBasePath}/matching-tcases.xml`
+				`junit-upload -r ${runURL} -t API_TOKEN --attachments ${xmlBasePath}/matching-tcases.xml`
 			)
 			expect(fileUploadCount()).toBe(5)
 			expect(tcaseUploadCount()).toBe(5)
@@ -126,7 +163,7 @@ describe('Uploading JUnit xml files', () => {
 			const tcaseUploadCount = countResultUploadApiCalls()
 			await expect(
 				run(
-					`junit-upload --url ${baseURL} -p ${projectCode} -r ${runId} -t API_TOKEN --attachments ${xmlBasePath}/missing-attachments.xml`
+					`junit-upload -r ${runURL} -t API_TOKEN --attachments ${xmlBasePath}/missing-attachments.xml`
 				)
 			).rejects.toThrow()
 			expect(fileUploadCount()).toBe(0)
@@ -136,7 +173,7 @@ describe('Uploading JUnit xml files', () => {
 			const fileUploadCount = countFileUploadApiCalls()
 			const tcaseUploadCount = countResultUploadApiCalls()
 			await run(
-				`junit-upload --url ${baseURL} -p ${projectCode} -r ${runId} -t API_TOKEN --attachments --force ${xmlBasePath}/missing-attachments.xml`
+				`junit-upload -r ${runURL} -t API_TOKEN --attachments --force ${xmlBasePath}/missing-attachments.xml`
 			)
 			expect(fileUploadCount()).toBe(4)
 			expect(tcaseUploadCount()).toBe(5)

--- a/src/utils/junit/JUnitCommandHandler.ts
+++ b/src/utils/junit/JUnitCommandHandler.ts
@@ -3,7 +3,7 @@ import { JUnitArgs } from '../../commands/junit-upload'
 import { parseJUnitXml, type JUnitResultType, type JUnitTestCase } from './junitXmlParser'
 import chalk from 'chalk'
 import { ResultStatus, RunTCase } from '../../api/schemas'
-import { parseApiToken, parseUrl, printError, printErrorThenExit, twirlLoader } from '../misc'
+import { parseApiToken, parseRunUrl, printError, printErrorThenExit, twirlLoader } from '../misc'
 import { Api, createApi } from '../../api'
 import { readFileSync } from 'fs'
 import { dirname } from 'path'
@@ -11,18 +11,33 @@ import { dirname } from 'path'
 export class JUnitCommandHandler {
 	private api: Api
 
+	private project: string
+
+	private run: number
+
 	constructor(private args: Arguments<JUnitArgs>) {
 		const apiToken = parseApiToken(args)
-		const url = parseUrl(args)
+		const {url, project, run} = parseRunUrl(args)
+
+		this.project = project
+		this.run = run
 		this.api = createApi(url, apiToken)
 	}
 
 	async handle() {
-		const file = readFileSync(this.args.file).toString()
-		const { testcases: junitResults } = await parseJUnitXml(file, dirname(this.args.file))
+		const junitResults : JUnitTestCase[] = []
+
+		console.log(`Uploading files [${this.args.files.map((f) => chalk.green(f)).join(", ")}]`+
+		` to run [${chalk.green(this.run)}] of project [${chalk.green(this.project)}]`)
+
+		for (const file of this.args.files) {
+			const xmlString = readFileSync(file).toString()
+			const { testcases: results } = await parseJUnitXml(xmlString, dirname(file))
+			junitResults.push(...results)
+		}
 
 		const tcases = await this.api.runs
-			.getRunTCases(this.args.project, this.args.run)
+			.getRunTCases(this.project, this.run)
 			.catch(printErrorThenExit)
 
 		const { results, missing } = this.mapTestCaseResults(junitResults, tcases)
@@ -84,7 +99,7 @@ export class JUnitCommandHandler {
 					comment += `\n<p>Attachments:</p>\n${makeListHtml(attachmentUrls)}`
 				}
 
-				await this.api.runs.createResultStatus(this.args.project, this.args.run, tcase.id, {
+				await this.api.runs.createResultStatus(this.project, this.run, tcase.id, {
 					status: getResult(result.type),
 					comment,
 				})
@@ -103,7 +118,7 @@ export class JUnitCommandHandler {
 			const tcase = testcases.find((tcase) => {
 				if (!result.name) return false
 
-				const tcaseCode = `${this.args.project}-${tcase.seq.toString().padStart(3, '0')}`
+				const tcaseCode = `${this.project}-${tcase.seq.toString().padStart(3, '0')}`
 				return result.name.includes(tcaseCode)
 			})
 			if (tcase) {

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -39,8 +39,8 @@ export const parseRunUrl = (args: Record<string, unknown>) => {
 			runUrl = `https://${runUrl}`
 		}
 
-		const matches = runUrl.match(/^(\S+)\/project\/(\w+)\/run\/(\d+)\/?$/)
-		if (matches && matches.length === 4) {
+		const matches = runUrl.match(/^(\S+)\/project\/(\w+)\/run\/(\d+)(\/\S*)?$/)
+		if (matches && matches.length === 5) {
 			return {
 				url: matches[1],
 				project: matches[2],

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -32,17 +32,23 @@ export const twirlLoader = () => {
 	}
 }
 
-export const parseUrl = (args: Record<string, unknown>): string => {
-	if (typeof args.url === 'string') {
-		if (args.url.includes('://')) {
-			return args.url
+export const parseRunUrl = (args: Record<string, unknown>) => {
+	if (typeof args.runUrl === 'string') {
+		let runUrl = args.runUrl
+		if (!runUrl.includes('://')) {
+			runUrl = `https://${runUrl}`
 		}
-		return `https://${args.url}`
+
+		const matches = runUrl.match(/^(\S+)\/project\/(\w+)\/run\/(\d+)\/?$/)
+		if (matches && matches.length === 4) {
+			return {
+				url: matches[1],
+				project: matches[2],
+				run: Number(matches[3]),
+			}
+		}
 	}
-	if (typeof args.s === 'string' && typeof args.z === 'string') {
-		return `https://${args.s}.${args.z}.qasphere.com`
-	}
-	throw new Error('missing parameters -z and -s or --url')
+	throw new Error('invalid --run-url specified')
 }
 
 export const parseApiToken = (args: Record<string, unknown>): string => {


### PR DESCRIPTION
* Allow user to enter multiple XML files. This also allows users to specify glob patterns
* Replace legacy arguments with single arg for the run url

This fixes https://github.com/Hypersequent/tms-issues/issues/472 and https://github.com/Hypersequent/tms-issues/issues/474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved command-line interface for the `qasphere` tool with updated options for specifying run URLs.

- **Bug Fixes**
  - Enhanced URL handling for test run uploads, ensuring better accuracy and robustness.

- **Documentation**
  - Updated README to reflect changes in command-line options and usage instructions for uploading JUnit XML files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->