### PR TITLE
Read token from environment variable or .qaspherecli file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,23 @@ npm link
 qasphere --version
 ```
 
+## Environment
+
+- The CLI requires following variables to be defined, absence of which will result in error
+  - `QAS_TOKEN` - QASphere API token
+- These should either be `export`ed as environment variables while running the command or defined in a `.qaspherecli` configuration file in the directory where the command is being run or one of its parent directories
+- `.qaspherecli` follows the simple syntax of `.env` files
+  ```sh
+  # Comment
+  QAS_TOKEN=token
+  QAS_TOKEN=token # comment
+  export QAS_TOKEN=token
+  ```
+
 ## Command: `junit-upload`
 
 ### Options
 
-- `-t, --token` - API token (string) - Can be generated under QASphere **Settings>API keys**
 - `-r, --run-url` - URL of the Run (from QASphere) for uploading results, eg. https://qas.eu1.qasphere.com/project/P1/run/23 (string)
 - `--attachments` - Try to detect any attachments and upload it with the test result (boolean)
 - `--force` - Ignore API request errors, invalid test cases, or attachments (boolean)
@@ -49,16 +61,18 @@ qasphere --version
 
 ### Examples
 
+Make sure that the required variables, as mentioned in [Environment](#environment), are defined before running the commands.
+
 1. Upload JUnit XML file to Run ID 23 of Project P1
 
 ```bash
-qasphere junit-upload -r https://qas.eu1.qasphere.com/project/P1/run/23 -t API_TOKEN ./path/to/junit.xml
+qasphere junit-upload -r https://qas.eu1.qasphere.com/project/P1/run/23 ./path/to/junit.xml
 ```
 
 2. To upload all (JUnit) XML files from the current directory to Run ID 23 of Project P1
 
 ```bash
-qasphere junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 --token API_TOKEN ./*.xml
+qasphere junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 ./*.xml
 ```
 
 ## How to Test
@@ -66,5 +80,6 @@ qasphere junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 -
 1. Build the code with `npm run build`.
 2. Create a project with test cases using local QASphere build or by registering on [qasphere.com](https://qasphere.com/)
 3. Get a JUnit XML file. If you want to test the test cases from the CSV file above, use the JUnit XML file generated from [this repository](https://github.com/Hypersequent/bistrot-e2e).
-4. Run the CLI with: `node ./build/bin/qasphere.js junit-upload -r QAS_URL/project/PROJECT_CODE/run/RUN_ID -t API_TOKEN ./JUnit.xml`. If you get permission errors, please retry after running: `chmod +x ./build/bin/qasphere.js`
-5. You may pass the `-h` flag to show help: `node ./build/bin/qasphere junit-upload -h`
+4. Define required variables as mentioned in [Environment](#environment).
+5. Run the CLI with: `node ./build/bin/qasphere.js junit-upload -r QAS_URL/project/PROJECT_CODE/run/RUN_ID ./JUnit.xml`. If you get permission errors, please retry after running: `chmod +x ./build/bin/qasphere.js`
+6. You may pass the `-h` flag to show help: `node ./build/bin/qasphere junit-upload -h`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "ISC",
 			"dependencies": {
 				"chalk": "^4.1.2",
+				"dotenv": "^16.4.5",
 				"escape-html": "^1.0.3",
 				"semver": "^7.6.2",
 				"xml2js": "^0.6.2",
@@ -1669,6 +1670,17 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.4.5",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 	},
 	"dependencies": {
 		"chalk": "^4.1.2",
+		"dotenv": "^16.4.5",
 		"escape-html": "^1.0.3",
 		"semver": "^7.6.2",
 		"xml2js": "^0.6.2",

--- a/src/bin/qasphere.ts
+++ b/src/bin/qasphere.ts
@@ -4,6 +4,7 @@ import { hideBin } from 'yargs/helpers'
 import { run } from '../commands/main'
 import { validateNodeVersion } from '../utils/misc'
 import { REQUIRED_NODE_VERSION } from '../utils/config'
+import { loadEnvs } from '../utils/env'
 import chalk from 'chalk'
 
 if (!validateNodeVersion()) {
@@ -14,4 +15,5 @@ if (!validateNodeVersion()) {
 	)
 }
 
+loadEnvs()
 run(hideBin(process.argv))

--- a/src/commands/junit-upload.ts
+++ b/src/commands/junit-upload.ts
@@ -1,6 +1,5 @@
 import { Arguments, Argv, CommandModule } from 'yargs'
 import { parseRunUrl } from '../utils/misc'
-import { API_TOKEN } from '../config/env'
 import { JUnitCommandHandler } from '../utils/junit/JUnitCommandHandler'
 
 export interface JUnitArgs {
@@ -17,12 +16,6 @@ export class JUnitUploadCommandModule implements CommandModule<unknown, JUnitArg
 
 	builder = (argv: Argv) => {
 		argv.options({
-			token: {
-				alias: 't',
-				describe: 'API token',
-				type: 'string',
-				requiresArg: true,
-			},
 			'run-url': {
 				alias: 'r',
 				describe: 'URL of the Run (from QASphere) for uploading results',
@@ -47,20 +40,13 @@ export class JUnitUploadCommandModule implements CommandModule<unknown, JUnitArg
 			return !!parseRunUrl(args)
 		})
 
-		argv.check((args) => {
-			if (!args.token && !API_TOKEN) {
-				throw new Error('-t <token> or QAS_TOKEN environment variable must be present')
-			}
-			return true
-		})
-
 		argv.example(
-			'$0 junit-upload -r https://qas.eu1.qasphere.com/project/P1/run/23 -t API_TOKEN ./path/to/junit.xml',
+			'$0 junit-upload -r https://qas.eu1.qasphere.com/project/P1/run/23 ./path/to/junit.xml',
 			'Upload JUnit xml file to Run ID 23 of Project P1'
 		)
 
 		argv.example(
-			'$0 junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 --token API_TOKEN *.xml',
+			'$0 junit-upload --run-url https://qas.eu1.qasphere.com/project/P1/run/23 *.xml',
 			'Upload all xml files in the current directory to Run ID 23 of Project P1'
 		)
 

--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -1,9 +1,13 @@
 import yargs from 'yargs'
 import { JUnitUploadCommandModule } from './junit-upload'
+import { qasEnvs, qasEnvFile } from '../utils/env'
 
 export const run = (args: string | string[]) =>
 	yargs(args)
-		.usage('$0 <command> [options]')
+		.usage(`$0 <command> [options]
+
+Required variables: ${qasEnvs.join(', ')}
+  These should be either exported as environment variables or defined in a ${qasEnvFile} file in the current directory or one of its parents.`)
 		.command(new JUnitUploadCommandModule())
 		.demandCommand()
 		.help('h')

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,1 +1,0 @@
-export const API_TOKEN = process.env.QAS_TOKEN

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,4 +1,1 @@
-export const getApiUrl = (subdomain: string, zone: string) =>
-	`https://${subdomain}.${zone}.qasphere.com`
-
 export const REQUIRED_NODE_VERSION = '18.0.0'

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,42 @@
+import { config, DotenvPopulateInput } from 'dotenv';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import chalk from 'chalk';
+
+export const qasEnvFile = '.qaspherecli'
+export const qasEnvs = ['QAS_TOKEN']
+
+export function loadEnvs(): void {
+	const fileEnvs : DotenvPopulateInput = {}
+	let dir = process.cwd();
+
+	for (;;) {
+		const envPath = join(dir, qasEnvFile);
+		if (existsSync(envPath)) {
+			config({ path: envPath, processEnv: fileEnvs });
+			break;
+		}
+
+		const parentDir = dirname(dir);
+		if (parentDir === dir) {
+			// If the parent directory is the same as the current, we've reached the root
+			break;
+		}
+
+		dir = parentDir;
+	}
+
+	const missingEnvs = []
+	for (const env of qasEnvs) {
+		process.env[env] ??= fileEnvs[env]
+		if (!process.env[env]) {
+			missingEnvs.push(env)
+		}
+	}
+
+	if (missingEnvs.length > 0) {
+		console.log(`${chalk.red('Missing inputs')}: ${missingEnvs.join(', ')}
+Please provide these as environment variables or declare them in .qaspherecli file in the current directory or one of its parents`)
+		process.exit(1)
+	}
+}

--- a/src/utils/junit/JUnitCommandHandler.ts
+++ b/src/utils/junit/JUnitCommandHandler.ts
@@ -3,7 +3,7 @@ import { JUnitArgs } from '../../commands/junit-upload'
 import { parseJUnitXml, type JUnitResultType, type JUnitTestCase } from './junitXmlParser'
 import chalk from 'chalk'
 import { ResultStatus, RunTCase } from '../../api/schemas'
-import { parseApiToken, parseRunUrl, printError, printErrorThenExit, twirlLoader } from '../misc'
+import { parseRunUrl, printError, printErrorThenExit, twirlLoader } from '../misc'
 import { Api, createApi } from '../../api'
 import { readFileSync } from 'fs'
 import { dirname } from 'path'
@@ -16,7 +16,7 @@ export class JUnitCommandHandler {
 	private run: number
 
 	constructor(private args: Arguments<JUnitArgs>) {
-		const apiToken = parseApiToken(args)
+		const apiToken = process.env.QAS_TOKEN!
 		const {url, project, run} = parseRunUrl(args)
 
 		this.project = project

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,5 +1,4 @@
 import { gte } from 'semver'
-import { API_TOKEN } from '../config/env'
 import { REQUIRED_NODE_VERSION } from './config'
 import chalk from 'chalk'
 
@@ -52,17 +51,6 @@ export const parseRunUrl = (args: Record<string, unknown>) => {
 		}
 	}
 	throw new Error('invalid --run-url specified')
-}
-
-export const parseApiToken = (args: Record<string, unknown>): string => {
-	if (typeof args.token === 'string') {
-		return args.token
-	}
-	if (API_TOKEN) {
-		return API_TOKEN
-	}
-
-	throw new Error('missing parameters --token')
 }
 
 export const printErrorThenExit = (e: unknown): never => {


### PR DESCRIPTION
* Add support to read configuration from environment variable or .qaspherecli configuration files
* Currently only QAS_TOKEN variable is read in this way
* Update README and examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README with new environment variable requirements and revised instructions for the `junit-upload` command.

- **New Features**
  - Added functionality to load environment variables from a configuration file.

- **Bug Fixes**
  - Removed the `-t, --token` option from the `junit-upload` command to rely on the `QAS_TOKEN` environment variable.

- **Dependencies**
  - Added `dotenv` package to manage environment variables.

- **Refactor**
  - Simplified API token handling by directly using the `QAS_TOKEN` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->