### PR TITLE
Ignore empty test suites

### DIFF
--- a/src/tests/fixtures/junit-xml/empty-tsuite.xml
+++ b/src/tests/fixtures/junit-xml/empty-tsuite.xml
@@ -1,0 +1,10 @@
+<testsuites id="" name="" tests="6" failures="1" skipped="0" errors="0" time="31.450767">
+  <testsuite name="ui.cart.spec.ts" timestamp="2024-04-22T09:25:16.777Z" hostname="chromium"
+    tests="2" failures="0" skipped="0" time="16.746" errors="0">
+    <testcase name="Test cart TEST-002" classname="ui.cart.spec.ts" time="10.686">
+    </testcase>
+  </testsuite>
+  <testsuite name="ui.contents.spec.ts" timestamp="2024-04-22T09:25:16.777Z" hostname="chromium"
+    tests="4" failures="1" skipped="0" time="28.38" errors="0">
+  </testsuite>
+</testsuites>

--- a/src/tests/junit-upload.spec.ts
+++ b/src/tests/junit-upload.spec.ts
@@ -149,6 +149,16 @@ describe('Uploading JUnit xml files', () => {
 			expect(fileUploadCount()).toBe(0)
 			expect(tcaseUploadCount()).toBe(8)
 		})
+
+		test('Test suite with empty tcases should not result in error and be skipped', async () => {
+			const fileUploadCount = countFileUploadApiCalls()
+			const tcaseUploadCount = countResultUploadApiCalls()
+			await run(
+				`junit-upload -r ${runURL} --force ${xmlBasePath}/empty-tsuite.xml`
+			)
+			expect(fileUploadCount()).toBe(0)
+			expect(tcaseUploadCount()).toBe(1)
+		})
 	})
 
 	describe('Uploading with attachments', () => {

--- a/src/utils/junit/junitXmlParser.ts
+++ b/src/utils/junit/junitXmlParser.ts
@@ -41,7 +41,7 @@ const xmlSchema = z.object({
 					time: z.string().optional(),
 					timeStamp: z.string().optional(),
 				}),
-				testcase: z.array(testCaseSchema),
+				testcase: z.array(testCaseSchema).optional(),
 			})
 		),
 	}),
@@ -77,7 +77,7 @@ export const parseJUnitXml = async (xmlString: string, basePath: string): Promis
 	const attachmentsPromises: Array<{ index: number; promise: Promise<JUnitAttachment[]> }> = []
 
 	for (const suite of validated.testsuites.testsuite) {
-		for (const tcase of suite.testcase) {
+		for (const tcase of suite.testcase??[]) {
 			const result = getResult(tcase)
 			const index =
 				testcases.push({


### PR DESCRIPTION
This fixes https://github.com/Hypersequent/tms-issues/issues/471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a test case to ensure that empty test suites do not result in errors and are skipped appropriately.

- **Bug Fixes**
  - Improved handling of empty test suites in JUnit XML parsing to prevent potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->