### PR TITLE
Check for project existence in JUnitResultUploader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 build
+.qaspherecli
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "qas-cli",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "qas-cli",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "ISC",
 			"dependencies": {
 				"chalk": "^4.1.2",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,13 +1,15 @@
-import { createFileApi } from './file'
+import { createProjectApi } from './projects'
 import { createRunApi } from './run'
 import { createTCaseApi } from './tcases'
+import { createFileApi } from './file'
 import { withApiKey, withBaseUrl } from './utils'
 
 const getApi = (fetcher: typeof fetch) => {
     return {
+        projects: createProjectApi(fetcher),
         runs: createRunApi(fetcher),
-        file: createFileApi(fetcher),
         testcases: createTCaseApi(fetcher),
+        file: createFileApi(fetcher),
     }
 }
 

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -1,0 +1,6 @@
+export const createProjectApi = (fetcher: typeof fetch) => ({
+	checkProjectExists: async (project: string) => {
+		const res = await fetcher(`/api/public/v0/project/${project}`)
+		return res.ok
+	},
+})

--- a/src/utils/junit/JUnitResultUploader.ts
+++ b/src/utils/junit/JUnitResultUploader.ts
@@ -54,6 +54,10 @@ export class JUnitResultUploader {
 			return
 		}
 
+		if (!(await this.api.projects.checkProjectExists(this.project))) {
+			return printErrorThenExit(`Project ${this.project} does not exist`)
+		}
+
 		// Create a new test run
 		console.log(chalk.blue(`Creating a new test run for project: ${this.project}`))
 		const tcaseRefs = await this.extractTestCaseRefs()
@@ -110,7 +114,7 @@ export class JUnitResultUploader {
 
 	private async createNewRun(tcases: PaginatedResponse<TCaseBySeq>) {
 		const runId = await this.api.runs.createRun(this.project, {
-			title: `Automated test run - ${new Date().toLocaleString('en-US', { 
+			title: `Automated test run - ${new Date().toLocaleString('en-US', {
 				year: 'numeric',
 				month: 'short',
 				day: '2-digit',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to check if a project exists before uploading JUnit results. If the project does not exist, an error message is displayed and the process stops.

- **Chores**
  - Updated the `.gitignore` file to exclude `.qaspherecli` and `.DS_Store` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->