### PR TITLE
Fix NPM Publish Github Action

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
```bash
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-05-19T11_31_38_368Z-debug-0.log
Error: Process completed with exit code 1.
```