### PR TITLE
Use testcase classname as folder in JUnit XML parser

### DIFF
--- a/src/tests/fixtures/junit-xml/pytest-style.xml
+++ b/src/tests/fixtures/junit-xml/pytest-style.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests">
+  <testsuite name="pytest" errors="0" failures="1" skipped="0" tests="4" time="3.5" timestamp="2026-02-09T12:00:00.000000+00:00" hostname="test-host">
+    <testcase classname="tests.login_test.TestLogin" name="TEST-002 test_valid_login[chromium]" time="0.649">
+    </testcase>
+    <testcase classname="tests.login_test.TestLogin" name="TEST-003 test_login_error[chromium-invalid_password]" time="0.625">
+    </testcase>
+    <testcase classname="tests.checkout_test.TestCheckout" name="TEST-004 test_checkout_counter[chromium-standard_user]" time="0.988">
+    </testcase>
+    <testcase classname="tests.inventory_test.TestInventory" name="TEST-006 test_inventory_page[chromium-standard_user]" time="0.584">
+      <failure message="AssertionError: expected True but got False">self = &lt;tests.inventory_test.TestInventory object&gt;
+
+    def test_inventory_page(self, page) -&gt; None:
+&gt;       assert page.title() == "Expected Title"
+E       AssertionError: expected True but got False
+
+tests/inventory_test.py:12: AssertionError</failure>
+    </testcase>
+    <testcase classname="tests.inventory_test.TestInventory" name="TEST-007 test_inventory_sort[chromium-standard_user]" time="0.734">
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
## Summary
- Parse the `classname` attribute from `<testcase>` elements in JUnit XML
- Use `classname` as the folder (for logging/display), falling back to suite name when absent
- Fixes poor folder grouping for pytest-based test runners (pytest-playwright, etc.) which put all tests in a single generic `<testsuite name="pytest">` while providing meaningful `classname` like `tests.login_test.TestLogin`

## Context
Python Playwright uses `pytest-playwright`, which generates JUnit XML via `--junitxml`. Unlike JS Playwright (which creates separate `<testsuite>` per spec file), pytest creates a single suite. The `classname` attribute provides the grouping info that was previously lost.

For test runners where classname already matches the suite name (JS Playwright, etc.), behavior is unchanged.

## Test plan
- [x] Added pytest-style JUnit XML test fixture
- [x] Added test verifying classname-based folder grouping
- [x] Added test verifying fallback to suite name when classname is absent
- [x] All 67 existing tests pass
- [x] Typecheck, lint, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)