### PR TITLE
[codex] Bump package version to 0.6.1 after #61

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qas-cli",
-  "version": "0.4.6",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qas-cli",
-      "version": "0.4.6",
+      "version": "0.6.1",
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qas-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "QAS CLI is a command line tool for submitting your automation test results to QA Sphere at https://qasphere.com/",
   "type": "module",
   "main": "./build/bin/qasphere.js",


### PR DESCRIPTION
## Summary

This is a small follow-up to [#61](https://github.com/Hypersequent/qas-cli/pull/61), which merged the Playwright upload mapping fixes into `main` on April 6, 2026.

This PR bumps the package version to `0.6.1` and aligns the root package metadata in `package-lock.json` with the published package version.

## Why this follow-up is needed

PR #61 delivered the functional fixes, but the repository version metadata was still left at `0.6.0` in `package.json`, and the root metadata in `package-lock.json` was even older at `0.4.6`.

Leaving that state in place would make the next publish ambiguous and could cause the release metadata to misrepresent what is actually on `main`.

## What changed

- Bumped `package.json` from `0.6.0` to `0.6.1`
- Updated the root `package-lock.json` package version fields from `0.4.6` to `0.6.1`
- Kept the change set intentionally narrow: no source, parser, uploader, or test logic changes

## User and release impact

- The next npm release can be cut as `0.6.1`, clearly marking it as the follow-up release that includes the fixes merged in #61
- `package.json` and `package-lock.json` will now agree on the package version at the repository root
- There is no runtime behavior change in this PR by itself

## Validation

- [x] `npm run check`

## Notes

- Base branch: `main`
- Follow-up to: #61