### PR TITLE
Add user details in `auth status`

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -7,6 +7,14 @@ export interface User {
 	role: string
 }
 
+export interface MeUser {
+	id: number
+	email: string
+	name: string
+	avatar: string | null
+	role: string
+}
+
 export const createUserApi = (fetcher: typeof fetch) => {
 	fetcher = withJson(fetcher)
 	return {
@@ -14,5 +22,9 @@ export const createUserApi = (fetcher: typeof fetch) => {
 			fetcher(`/api/public/v0/users`)
 				.then((r) => jsonResponse<{ users: User[] }>(r))
 				.then((r) => r.users),
+		me: () =>
+			fetcher(`/api/public/v0/users/me`)
+				.then((r) => jsonResponse<{ user: MeUser }>(r))
+				.then((r) => r.user),
 	}
 }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -172,8 +172,9 @@ async function handleStatus(): Promise<void> {
 	let valid = false
 	try {
 		const api = createApi(tenantUrl, token, result.authType)
-		await api.projects.list()
+		const me = await api.users.me()
 		console.log(`  Status: ${chalk.green('valid')}`)
+		console.log(`  User: ${me.name} <${me.email}> (${me.role})`)
 		valid = true
 	} catch {
 		console.log(`  Status: ${chalk.red('invalid or expired')}`)

--- a/src/tests/auth-e2e.spec.ts
+++ b/src/tests/auth-e2e.spec.ts
@@ -45,15 +45,23 @@ const tokenSuccessHandler = (expiresIn = 3600, refreshExpiresIn = 90 * 24 * 3600
 		})
 	})
 
-const projectsHandler = http.get(`${tenantUrl}/api/public/v0/project`, ({ request }) => {
+const testMeUser = {
+	id: 42,
+	email: 'tester@example.com',
+	name: 'Test User',
+	avatar: null,
+	role: 'admin',
+}
+
+const meHandler = http.get(`${tenantUrl}/api/public/v0/users/me`, ({ request }) => {
 	const auth = request.headers.get('Authorization')
 	if (auth === `ApiKey ${testApiKey}` || auth === `Bearer ${testAccessToken}`) {
-		return HttpResponse.json({ data: [], total: 0 })
+		return HttpResponse.json({ user: testMeUser })
 	}
 	return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 })
 })
 
-const server = setupServer(checkTenantHandler, projectsHandler)
+const server = setupServer(checkTenantHandler, meHandler)
 
 // --- Hoisted mock state ---
 // vi.hoisted runs before imports, so vi.mock factories can reference these.
@@ -395,6 +403,11 @@ describe('auth login → status → logout lifecycle', () => {
 			)
 			expect(log).toHaveBeenCalledWith(expect.stringContaining('credentials.json'))
 			expect(log).toHaveBeenCalledWith(expect.stringContaining('valid'))
+			expect(log).toHaveBeenCalledWith(
+				expect.stringContaining(
+					`User: ${testMeUser.name} <${testMeUser.email}> (${testMeUser.role})`
+				)
+			)
 			expect(log).toHaveBeenCalledWith(
 				expect.stringMatching(/Re-authentication required: in (89|90) days \(resets on each use\)/)
 			)
@@ -884,10 +897,10 @@ describe('token refresh at load time', () => {
 					{ status: 401 }
 				)
 			}),
-			http.get(`${tenantUrl}/api/public/v0/project`, ({ request }) => {
+			http.get(`${tenantUrl}/api/public/v0/users/me`, ({ request }) => {
 				const auth = request.headers.get('Authorization')
 				if (auth === `Bearer ${refreshedAccessToken}`) {
-					return HttpResponse.json({ data: [], total: 0 })
+					return HttpResponse.json({ user: testMeUser })
 				}
 				return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 })
 			})
@@ -981,10 +994,10 @@ describe('token refresh at load time', () => {
 					{ status: 401 }
 				)
 			}),
-			http.get(`${tenantUrl}/api/public/v0/project`, ({ request }) => {
+			http.get(`${tenantUrl}/api/public/v0/users/me`, ({ request }) => {
 				const auth = request.headers.get('Authorization')
 				if (auth === `Bearer ${refreshedAccessToken}`) {
-					return HttpResponse.json({ data: [], total: 0 })
+					return HttpResponse.json({ user: testMeUser })
 				}
 				return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 })
 			})


### PR DESCRIPTION
Sample output:
```
  Credentials connected via https://acme.eu1.qasphere.com
    Source: credentials.json
    Status: valid
    User: Test User <tester@example.com> (admin)
    Re-authentication required: in 89 days (resets on each use)
```