### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qas-cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qas-cli",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "ISC",
       "dependencies": {
         "@napi-rs/keyring": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qas-cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "QAS CLI is a command line tool for submitting your automation test results to QA Sphere at https://qasphere.com/",
   "type": "module",
   "main": "./build/bin/qasphere.js",


### PR DESCRIPTION
## Summary

Bumps `package.json` (and `package-lock.json`) from `0.7.0` to `0.8.0` in preparation for the v0.8.0 release.

## What's shipping in v0.8.0

- #64 Add interactive login — new `qasphere auth` commands (`login`, `logout`, `status`) using OAuth 2.0 Device Authorization Grant, with OS keyring storage and a permission-restricted file fallback. Backwards compatible with existing `QAS_TOKEN`/`QAS_URL` env-based auth.
- #66 Improve README.md — highlights public API commands and agentic workflows.

Once this is merged, a `v0.8.0` GitHub Release will trigger `.github/workflows/npm.yml` to publish to npm.

## Test plan

- [x] `package.json` version is `0.8.0`
- [x] `package-lock.json` root + lockfile entries updated to `0.8.0`
- [ ] CI passes on this branch