### PR TITLE
chore: require Node.js >=22 and document auth login in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Because the agent reads the same `--help` output a human would, you don't need t
 
 ### Requirements
 
-Node.js version 18.0.0 or higher.
+Node.js version 22.0.0 or higher.
 
 ### Via NPX
 
@@ -472,7 +472,7 @@ This project uses [pnpm](https://pnpm.io/) (declared via the `packageManager` fi
 
 1. Install and build: `pnpm install && pnpm build && pnpm link --global`
 2. Get test account at [qasphere.com](https://qasphere.com/) (includes demo project)
-3. Configure `.qaspherecli` with credentials
+3. Authenticate: run `qasphere auth login` (OAuth via browser — no API key to create or `.qaspherecli` to manage), or configure `QAS_TOKEN`/`QAS_URL` in a `.qaspherecli` file
 4. Test with sample reports from [bistro-e2e](https://github.com/Hypersequent/bistro-e2e)
 
-Tests: `pnpm test` (Vitest) and `cd mnode-test && ./docker-test.sh` (Node.js 18+ compatibility)
+Tests: `pnpm test` (Vitest) and `cd mnode-test && ./docker-test.sh` (Node.js 22+ compatibility)

--- a/mnode-test/docker-test.sh
+++ b/mnode-test/docker-test.sh
@@ -52,7 +52,7 @@ EXPECTED_VERSION=$(node -p "require('${PROJECT_DIR}/package.json').version")
 echo "Expected version: ${EXPECTED_VERSION}"
 echo ""
 
-NODE_VERSIONS=("18" "20" "22" "24")
+NODE_VERSIONS=("22" "24")
 
 # Get current user ID for fixing permissions on Linux
 FIX_PERMS="true"  # Default no-op command

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@11.1.2",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "main": "./build/bin/qasphere.js",
   "types": "./build/bin/qasphere.d.ts",
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@eslint/js": "^9.25.1",
     "@types/escape-html": "^1.0.4",
-    "@types/node": "^20.17.32",
+    "@types/node": "^22.0.0",
     "@types/semver": "^7.7.0",
     "@types/xml2js": "^0.4.14",
     "@types/yargs": "^17.0.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       '@types/node':
-        specifier: ^20.17.32
-        version: 20.17.32
+        specifier: ^22.0.0
+        version: 22.19.21
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.0
@@ -71,7 +71,7 @@ importers:
         version: 15.5.2
       msw:
         specifier: ^2.7.5
-        version: 2.7.5(@types/node@20.17.32)(typescript@5.8.3)
+        version: 2.7.5(@types/node@22.19.21)(typescript@5.8.3)
       prettier:
         specifier: ^3.4.2
         version: 3.7.4
@@ -86,7 +86,7 @@ importers:
         version: 8.31.1(eslint@9.39.4)(typescript@5.8.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@20.17.32)(msw@2.7.5(@types/node@20.17.32)(typescript@5.8.3))(vite@8.0.0(@types/node@20.17.32)(yaml@2.8.2))
+        version: 4.1.0(@types/node@22.19.21)(msw@2.7.5(@types/node@22.19.21)(typescript@5.8.3))(vite@8.0.0(@types/node@22.19.21)(yaml@2.8.2))
 
 packages:
 
@@ -438,8 +438,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@20.17.32':
-    resolution: {integrity: sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw==}
+  '@types/node@22.19.21':
+    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
@@ -1340,8 +1340,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -1583,17 +1583,17 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
-  '@inquirer/confirm@5.1.9(@types/node@20.17.32)':
+  '@inquirer/confirm@5.1.9(@types/node@22.19.21)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@20.17.32)
-      '@inquirer/type': 3.0.6(@types/node@20.17.32)
+      '@inquirer/core': 10.1.10(@types/node@22.19.21)
+      '@inquirer/type': 3.0.6(@types/node@22.19.21)
     optionalDependencies:
-      '@types/node': 20.17.32
+      '@types/node': 22.19.21
 
-  '@inquirer/core@10.1.10(@types/node@20.17.32)':
+  '@inquirer/core@10.1.10(@types/node@22.19.21)':
     dependencies:
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.6(@types/node@20.17.32)
+      '@inquirer/type': 3.0.6(@types/node@22.19.21)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -1601,13 +1601,13 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 20.17.32
+      '@types/node': 22.19.21
 
   '@inquirer/figures@1.0.11': {}
 
-  '@inquirer/type@3.0.6(@types/node@20.17.32)':
+  '@inquirer/type@3.0.6(@types/node@22.19.21)':
     optionalDependencies:
-      '@types/node': 20.17.32
+      '@types/node': 22.19.21
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -1774,9 +1774,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@20.17.32':
+  '@types/node@22.19.21':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.21.0
 
   '@types/semver@7.7.0': {}
 
@@ -1786,7 +1786,7 @@ snapshots:
 
   '@types/xml2js@0.4.14':
     dependencies:
-      '@types/node': 20.17.32
+      '@types/node': 22.19.21
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -1880,14 +1880,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(msw@2.7.5(@types/node@20.17.32)(typescript@5.8.3))(vite@8.0.0(@types/node@20.17.32)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.0(msw@2.7.5(@types/node@22.19.21)(typescript@5.8.3))(vite@8.0.0(@types/node@22.19.21)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.7.5(@types/node@20.17.32)(typescript@5.8.3)
-      vite: 8.0.0(@types/node@20.17.32)(yaml@2.8.2)
+      msw: 2.7.5(@types/node@22.19.21)(typescript@5.8.3)
+      vite: 8.0.0(@types/node@22.19.21)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -2368,12 +2368,12 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.5(@types/node@20.17.32)(typescript@5.8.3):
+  msw@2.7.5(@types/node@22.19.21)(typescript@5.8.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.9(@types/node@20.17.32)
+      '@inquirer/confirm': 5.1.9(@types/node@22.19.21)
       '@mswjs/interceptors': 0.37.6
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
@@ -2631,7 +2631,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  undici-types@6.19.8: {}
+  undici-types@6.21.0: {}
 
   universalify@0.2.0: {}
 
@@ -2644,7 +2644,7 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  vite@8.0.0(@types/node@20.17.32)(yaml@2.8.2):
+  vite@8.0.0(@types/node@22.19.21)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -2653,14 +2653,14 @@ snapshots:
       rolldown: 1.0.0-rc.9
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 20.17.32
+      '@types/node': 22.19.21
       fsevents: 2.3.3
       yaml: 2.8.2
 
-  vitest@4.1.0(@types/node@20.17.32)(msw@2.7.5(@types/node@20.17.32)(typescript@5.8.3))(vite@8.0.0(@types/node@20.17.32)(yaml@2.8.2)):
+  vitest@4.1.0(@types/node@22.19.21)(msw@2.7.5(@types/node@22.19.21)(typescript@5.8.3))(vite@8.0.0(@types/node@22.19.21)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.7.5(@types/node@20.17.32)(typescript@5.8.3))(vite@8.0.0(@types/node@20.17.32)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(msw@2.7.5(@types/node@22.19.21)(typescript@5.8.3))(vite@8.0.0(@types/node@22.19.21)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -2677,10 +2677,10 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@types/node@20.17.32)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@22.19.21)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.17.32
+      '@types/node': 22.19.21
     transitivePeerDependencies:
       - msw
 

--- a/skills/qas-cli/SKILL.md
+++ b/skills/qas-cli/SKILL.md
@@ -21,7 +21,7 @@ If working within the qas-cli repository itself, use `node build/bin/qasphere.js
 
 ## Prerequisites
 
-- **Node.js** 18.0.0+
+- **Node.js** 22.0.0+
 
 ### Authentication
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,2 +1,2 @@
-export const REQUIRED_NODE_VERSION = '18.0.0'
+export const REQUIRED_NODE_VERSION = '22.0.0'
 export const LOGIN_SERVICE_URL = process.env.QAS_LOGIN_SERVICE_URL || 'https://login.qasphere.com'


### PR DESCRIPTION
Follow-up to #70 (pnpm migration), addressing two review comments left on that PR.

## 1. Raise the Node.js floor to >=22

Node 18 (EOL Apr 2025) and Node 20 (EOL ~Apr 2026) are both end-of-life, so `>=18.0.0` advertised support for two EOL lines. This bumps the floor to the current maintenance LTS, Node 22 (supported through ~Apr 2027). Picking 22 over 24 keeps the floor conservative — it's the oldest still-supported LTS, which is what an `engines` floor should be.

Updated everywhere the version is referenced, to keep them in sync:

- `package.json` — `engines.node` `>=18.0.0` → `>=22.0.0`; `@types/node` `^20` → `^22` (lockfile regenerated)
- `src/utils/config.ts` — `REQUIRED_NODE_VERSION` `18.0.0` → `22.0.0` (drives the runtime version warning)
- `README.md` — Requirements + compatibility-test note
- `skills/qas-cli/SKILL.md` — Prerequisites
- `mnode-test/docker-test.sh` — drops 18/20 from the test matrix, keeps 22/24

The runtime check only *warns*, it doesn't block, so existing older installs still degrade gracefully.

## 2. Mention `auth login` in contributor setup

The Development setup step previously said only "Configure `.qaspherecli` with credentials". It now points to `qasphere auth login` (OAuth via browser — no API key to create or `.qaspherecli` to manage) first, with the manual `QAS_TOKEN`/`QAS_URL` route as the alternative.

## Checks

`pnpm check` (typecheck + lint + format) passes.