### PR TITLE
ci: auto-format Dependabot PRs after dependency bumps

### DIFF
--- a/.github/workflows/dependabot-autoformat.yml
+++ b/.github/workflows/dependabot-autoformat.yml
@@ -1,0 +1,62 @@
+name: Dependabot auto-format
+
+# Dependabot regenerates the whole lockfile on every bump, which can silently
+# move the *resolved* prettier/eslint version (within the existing semver range)
+# and reformat source files. Dependabot never runs project scripts, and its
+# commits are made via the API so they bypass the local husky/lint-staged hook.
+# The result is that `pnpm check` fails on style even though no source was
+# touched. This workflow reformats such PRs and pushes the fix back.
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependabot-autoformat-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  autoformat:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+          # A PAT / GitHub App token is required so the pushed commit retriggers
+          # CI (commits pushed with the default GITHUB_TOKEN do NOT start new
+          # workflow runs, so the failing check would stay stale). Falls back to
+          # GITHUB_TOKEN — the fix still lands, but CI won't re-run on its own.
+          token: ${{ secrets.DEPENDABOT_AUTOFIX_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply formatting and lint fixes
+        run: |
+          pnpm format
+          pnpm lint:fix
+
+      - name: Commit and push if changed
+        run: |
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No formatting changes needed."
+            exit 0
+          fi
+          git config user.name 'dependabot[bot]'
+          git config user.email '49699333+dependabot[bot]@users.noreply.github.com'
+          git commit -am 'chore(deps): apply formatting after dependency bump'
+          git push

--- a/.github/workflows/dependabot-autoformat.yml
+++ b/.github/workflows/dependabot-autoformat.yml
@@ -27,11 +27,11 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
-          # A PAT / GitHub App token is required so the pushed commit retriggers
-          # CI (commits pushed with the default GITHUB_TOKEN do NOT start new
-          # workflow runs, so the failing check would stay stale). Falls back to
-          # GITHUB_TOKEN — the fix still lands, but CI won't re-run on its own.
-          token: ${{ secrets.DEPENDABOT_AUTOFIX_TOKEN || secrets.GITHUB_TOKEN }}
+          # Do not persist any credential: the install/format steps below execute
+          # code controlled by the dependency bump (install scripts, prettier,
+          # eslint), which could otherwise read a persisted write token from
+          # .git/config. The write token is injected only in the push step.
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -51,6 +51,12 @@ jobs:
           pnpm lint:fix
 
       - name: Commit and push if changed
+        env:
+          # A PAT / GitHub App token is required so the pushed commit retriggers
+          # CI (commits pushed with the default GITHUB_TOKEN do NOT start new
+          # workflow runs, so the failing check would stay stale). Falls back to
+          # GITHUB_TOKEN — the fix still lands, but CI won't re-run on its own.
+          PUSH_TOKEN: ${{ secrets.DEPENDABOT_AUTOFIX_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           if [[ -z "$(git status --porcelain)" ]]; then
             echo "No formatting changes needed."
@@ -59,4 +65,4 @@ jobs:
           git config user.name 'dependabot[bot]'
           git config user.email '49699333+dependabot[bot]@users.noreply.github.com'
           git commit -am 'chore(deps): apply formatting after dependency bump'
-          git push
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_HEAD_REF}"


### PR DESCRIPTION
## Problem

Dependabot regenerates the entire \`pnpm-lock.yaml\` on every bump. That can silently move the **resolved** version of a formatter/linter within the existing semver range, reformatting source files without any manifest change.

Concrete case — PR #79: it only bumps \`globals\` and \`lint-staged\` in \`package.json\`, but the lockfile regen moved prettier **3.8.4 → 3.9.4** (both satisfy \`^3.4.2\`). Prettier 3.9.4 reformats a union type in \`src/utils/result-upload/parsers/junitXmlParser.ts\`, so \`pnpm check\` → \`prettier --check\` fails even though Dependabot touched no source.

Dependabot never runs project scripts (\`pnpm format\`), and its commits are made via the API so they **bypass the husky/lint-staged pre-commit hook**. Nothing in the pipeline reformats source after a formatter bump.

## Fix

A workflow that, on Dependabot \`pull_request\` events, runs \`pnpm format\` + \`pnpm lint:fix\` and pushes any resulting changes back to the PR branch.

## ⚠️ Required setup — \`DEPENDABOT_AUTOFIX_TOKEN\` secret

Commits pushed with the default \`GITHUB_TOKEN\` do **not** trigger new workflow runs, so the failing \`build\` check would stay stale (red) even after the fix lands. To make CI re-run and go green, the push must use a **PAT or GitHub App token**:

- Create a fine-grained PAT (or App installation token) with **Contents: read/write** on this repo.
- Add it as a repo secret named \`DEPENDABOT_AUTOFIX_TOKEN\`.

The workflow falls back to \`GITHUB_TOKEN\` if the secret is absent — the formatting fix still lands, but CI won't automatically re-run.

## Notes

- Only runs when \`github.actor == 'dependabot[bot]'\`.
- Applies to **future** Dependabot PRs (their branches are cut from \`main\` and will include this workflow). PR #79 predates it and needs a one-off manual \`pnpm format\` push (or a rebase after merge) to unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)