### PR TITLE
fix: never send empty tag names from --tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qas-cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "QAS CLI is a command line tool for submitting your automation test results to QA Sphere at https://qasphere.com/",
   "type": "module",
   "packageManager": "pnpm@11.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qas-cli",
-  "version": "0.11.0",
+  "version": "0.10.1",
   "description": "QAS CLI is a command line tool for submitting your automation test results to QA Sphere at https://qasphere.com/",
   "type": "module",
   "packageManager": "pnpm@11.1.2",

--- a/src/commands/api/manifests/test-cases.ts
+++ b/src/commands/api/manifests/test-cases.ts
@@ -33,7 +33,7 @@ const help = {
 	'precondition-text':
 		'Precondition text (supports HTML). Mutually exclusive with --precondition-id.',
 	'precondition-id': 'Shared precondition ID. Mutually exclusive with --precondition-text.',
-	tags: 'Comma-separated tag names (e.g., "smoke,regression").',
+	tags: 'Comma-separated tag names (e.g., "smoke,regression"). On update, --tags "" clears all tags.',
 	'is-draft': 'Whether the test case is a draft.',
 	draft: 'Filter by draft status (true or false).',
 	steps:
@@ -223,7 +223,10 @@ function transformTCaseFields(fields: Record<string, unknown>): Record<string, u
 
 	// Handle comma-separated tags
 	if (typeof fields.tags === 'string') {
-		result.tags = fields.tags.split(',')
+		result.tags = fields.tags
+			.split(',')
+			.map((tag) => tag.trim())
+			.filter((tag) => !!tag)
 	}
 
 	return result

--- a/src/tests/api/test-cases/create.spec.ts
+++ b/src/tests/api/test-cases/create.spec.ts
@@ -378,6 +378,54 @@ describe('mocked', () => {
 			steps: [{ description: 'Step 1', expected: 'Result 1' }],
 		})
 	})
+
+	test('--tags "" sends an empty tags array', async ({ project }) => {
+		await runCommand(
+			'--project-code',
+			project.code,
+			'--title',
+			'No tags',
+			'--type',
+			'standalone',
+			'--folder-id',
+			'1',
+			'--priority',
+			'medium',
+			'--tags',
+			''
+		)
+		expect(lastRequest).toEqual({
+			title: 'No tags',
+			type: 'standalone',
+			folderId: 1,
+			priority: 'medium',
+			tags: [],
+		})
+	})
+
+	test('trims tag names and drops empty ones', async ({ project }) => {
+		await runCommand(
+			'--project-code',
+			project.code,
+			'--title',
+			'Messy tags',
+			'--type',
+			'standalone',
+			'--folder-id',
+			'1',
+			'--priority',
+			'medium',
+			'--tags',
+			' smoke , ,regression, '
+		)
+		expect(lastRequest).toEqual({
+			title: 'Messy tags',
+			type: 'standalone',
+			folderId: 1,
+			priority: 'medium',
+			tags: ['smoke', 'regression'],
+		})
+	})
 })
 
 test('creates a test case on live server', { tags: ['live'] }, async ({ project }) => {

--- a/src/tests/api/test-cases/update.spec.ts
+++ b/src/tests/api/test-cases/update.spec.ts
@@ -151,6 +151,23 @@ describe('mocked', () => {
 		})
 	})
 
+	test('--tags "" clears tags by sending an empty array', async ({ project }) => {
+		await runCommand('--project-code', project.code, '--tcase-id', 'tc1', '--tags', '')
+		expect(lastRequest).toEqual({ tags: [] })
+	})
+
+	test('trims tag names and drops empty ones', async ({ project }) => {
+		await runCommand(
+			'--project-code',
+			project.code,
+			'--tcase-id',
+			'tc1',
+			'--tags',
+			' smoke , ,e2e '
+		)
+		expect(lastRequest).toEqual({ tags: ['smoke', 'e2e'] })
+	})
+
 	test('updates a test case with custom fields', async ({ project }) => {
 		const body = {
 			customFields: {


### PR DESCRIPTION
Issue: `--tags ""` on `test-cases update` sent `[""]` to the API, which created a tag with an empty title instead of clearing the case's tags.
- `transformTCaseFields` now trims tag names and drops empty entries, so `--tags ""` (and stray commas like `--tags "a,,b"`) never produce empty tag names.
- `--tags ""` sends an empty `tags` array on both create and update: a no-op on create, and clears all tags on update (the backend treats a non-nil empty array as "clear").
- Documented the clearing behavior in the `--tags` help text.

